### PR TITLE
[macos] Added Connectivity

### DIFF
--- a/Xamarin.Essentials/Connectivity/Connectivity.mac.reachability.cs
+++ b/Xamarin.Essentials/Connectivity/Connectivity.mac.reachability.cs
@@ -1,0 +1,147 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Net;
+using System.Threading.Tasks;
+using CoreFoundation;
+using SystemConfiguration;
+
+namespace Xamarin.Essentials
+{
+    enum NetworkStatus
+    {
+        NotReachable,
+        ReachableViaWiFiNetwork
+    }
+
+    static class Reachability
+    {
+        internal const string HostName = "www.microsoft.com";
+
+        internal static NetworkStatus RemoteHostStatus()
+        {
+            using (var remoteHostReachability = new NetworkReachability(HostName))
+            {
+                var reachable = remoteHostReachability.TryGetFlags(out var flags);
+
+                if (!reachable)
+                    return NetworkStatus.NotReachable;
+
+                if (!IsReachableWithoutRequiringConnection(flags))
+                    return NetworkStatus.NotReachable;
+
+                return NetworkStatus.ReachableViaWiFiNetwork;
+            }
+        }
+
+        internal static NetworkStatus InternetConnectionStatus()
+        {
+            var status = NetworkStatus.NotReachable;
+
+            var defaultNetworkAvailable = IsNetworkAvailable(out var flags);
+
+            // If the connection is reachable and no connection is required, then assume it's WiFi
+            if (defaultNetworkAvailable)
+            {
+                status = NetworkStatus.ReachableViaWiFiNetwork;
+            }
+
+            // If the connection is on-demand or on-traffic and no user intervention
+            // is required, then assume WiFi.
+            if (((flags & NetworkReachabilityFlags.ConnectionOnDemand) != 0 || (flags & NetworkReachabilityFlags.ConnectionOnTraffic) != 0) &&
+                 (flags & NetworkReachabilityFlags.InterventionRequired) == 0)
+            {
+                status = NetworkStatus.ReachableViaWiFiNetwork;
+            }
+
+            return status;
+        }
+
+        internal static IEnumerable<NetworkStatus> GetActiveConnectionType()
+        {
+            var status = new List<NetworkStatus>();
+
+            var defaultNetworkAvailable = IsNetworkAvailable(out var flags);
+
+            if (defaultNetworkAvailable)
+            {
+                status.Add(NetworkStatus.ReachableViaWiFiNetwork);
+            }
+            else if (((flags & NetworkReachabilityFlags.ConnectionOnDemand) != 0 || (flags & NetworkReachabilityFlags.ConnectionOnTraffic) != 0) &&
+                     (flags & NetworkReachabilityFlags.InterventionRequired) == 0)
+            {
+                // If the connection is on-demand or on-traffic and no user intervention
+                // is required, then assume WiFi.
+                status.Add(NetworkStatus.ReachableViaWiFiNetwork);
+            }
+
+            return status;
+        }
+
+        internal static bool IsNetworkAvailable(out NetworkReachabilityFlags flags)
+        {
+            var ip = new IPAddress(0);
+            using (var defaultRouteReachability = new NetworkReachability(ip))
+            {
+                if (!defaultRouteReachability.TryGetFlags(out flags))
+                    return false;
+
+                return IsReachableWithoutRequiringConnection(flags);
+            }
+        }
+
+        internal static bool IsReachableWithoutRequiringConnection(NetworkReachabilityFlags flags)
+        {
+            // Is it reachable with the current network configuration?
+            var isReachable = (flags & NetworkReachabilityFlags.Reachable) != 0;
+
+            // Do we need a connection to reach it?
+            var noConnectionRequired = (flags & NetworkReachabilityFlags.ConnectionRequired) == 0;
+
+            return isReachable && noConnectionRequired;
+        }
+    }
+
+    class ReachabilityListener : IDisposable
+    {
+        NetworkReachability defaultRouteReachability;
+        NetworkReachability remoteHostReachability;
+
+        internal ReachabilityListener()
+        {
+            var ip = new IPAddress(0);
+            defaultRouteReachability = new NetworkReachability(ip);
+            defaultRouteReachability.SetNotification(OnChange);
+            defaultRouteReachability.Schedule(CFRunLoop.Main, CFRunLoop.ModeDefault);
+
+            remoteHostReachability = new NetworkReachability(Reachability.HostName);
+
+            // Need to probe before we queue, or we wont get any meaningful values
+            // this only happens when you create NetworkReachability from a hostname
+            remoteHostReachability.TryGetFlags(out var flags);
+
+            remoteHostReachability.SetNotification(OnChange);
+            remoteHostReachability.Schedule(CFRunLoop.Main, CFRunLoop.ModeDefault);
+        }
+
+        internal event Action ReachabilityChanged;
+
+        void IDisposable.Dispose() => Dispose();
+
+        internal void Dispose()
+        {
+            defaultRouteReachability?.Dispose();
+            defaultRouteReachability = null;
+            remoteHostReachability?.Dispose();
+            remoteHostReachability = null;
+        }
+
+        async void OnChange(NetworkReachabilityFlags flags)
+        {
+            // Add in artifical delay so the connection status has time to change
+            // else it will return true no matter what.
+            await Task.Delay(100);
+
+            ReachabilityChanged?.Invoke();
+        }
+    }
+}


### PR DESCRIPTION
### Description of Change ###

Added implementation of Connectivity plugin for macOs platforms

### Bugs Fixed ###

- Related to issue https://github.com/xamarin/Essentials/issues/111

### API Changes ###

None (just added macOs support)

### Behavioral Changes ###

Try to build **Xamarin.Essentials.Additional** and run **Mac** sample. Open **Connectivity** tab:
Actual behavior: crash
Expected: it shows info re network status

<img width="624" alt="2" src="https://user-images.githubusercontent.com/10124814/53607459-e3f0f800-3bcf-11e9-8141-09494714a81a.png">
<img width="558" alt="1" src="https://user-images.githubusercontent.com/10124814/53607460-e4898e80-3bcf-11e9-915a-97eb6a7b4b63.png">




